### PR TITLE
Allow to make a copy without using file system cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,39 @@ type interface FsSyncer {
 fssync.New(opts... func(*FsSyncer))
 
 // Options
-// Check with checksum instead of size/mtime
+// WithChecksum option: Check SHA1 checksum instead of modtime + size
 fssync.WithChecksum
 
-// Preserve Owner/Group (require root), will return an error otherwise
+// PreserveOwnership option: chown files from source owner instead of copying
+// with current owner root required to change the user ownership in most cases
 fssync.PreserveOwnership
 
-// Ignore if files are being deleted during the sync (if a process is
-// creating/destroyging quickly files in the source, it might happen)
+// IgnoreNotFound option: if the synced directory is heavily used during the
+// sync there might be a file which is walked in but which does not exist
+// anymore when Lstat is used
 fssync.IgnoreNotFound
+
+// NoCache option: Use the system call fadvise to discard kernel cache after
+// reading/writing Inspired from
+// https://github.com/coreutils/coreutils/blob/master/src/dd.c
+fssync.NoCache
+
+// WithBufferSize option: lets you configure the size of the memory buffer used
+// to perform the copy from one file to another
+// Default is 512kB
+WithBufferSize(n int64)
 ```
 
 By default the copy is based on the size + modification date
+
+
+## Command line tool
+
+You can try out the synchronisation mecanisms with the command line tool
+provided with the library:
+
+```
+go get github.com/Scalingo/go-fssync/cmd/fssync
+
+fssync [-no-cache=false] [-buffer-size=0] [-preserve-ownership=false] [-checksum=false] ./src ./dst
+```

--- a/cmd/fssync/main.go
+++ b/cmd/fssync/main.go
@@ -10,6 +10,8 @@ import (
 func main() {
 	withCheckum := flag.Bool("checksum", false, "compare files with checksum")
 	preserveOwnership := flag.Bool("preserve-ownership", false, "preservice ownership of source")
+	noCache := flag.Bool("no-cache", false, "don't cache read/write content")
+	bufferSize := flag.Int64("buffer-size", 0, "size of the buffer to use during the copy (512kB by default)")
 
 	flag.Parse()
 
@@ -19,6 +21,12 @@ func main() {
 	}
 	if *preserveOwnership {
 		options = append(options, fssync.PreserveOwnership)
+	}
+	if *noCache {
+		options = append(options, fssync.NoCache)
+	}
+	if *bufferSize != 0 {
+		options = append(options, fssync.WithBufferSize(*bufferSize))
 	}
 	syncer := fssync.New(options...)
 

--- a/copy.go
+++ b/copy.go
@@ -1,0 +1,46 @@
+package fssync
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// copyContent is highly inspired from io.Copy, but calls to fadvise have been
+// added to prevent caching the whole content of the files during the process,
+// impacting the whole OS disk cache
+func (s *FsSyncer) copyContent(src, dst *os.File) (written int64, err error) {
+	buf := make([]byte, s.bufferSize)
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			if s.noCache {
+				unix.Fadvise(int(src.Fd()), written, written+int64(nr), unix.FADV_DONTNEED)
+			}
+
+			nw, ew := dst.Write(buf[0:nr])
+			if nw > 0 {
+				if s.noCache {
+					unix.Fadvise(int(dst.Fd()), written, written+int64(nw), unix.FADV_DONTNEED)
+				}
+				written += int64(nw)
+			}
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				err = er
+			}
+			break
+		}
+	}
+	return written, err
+}

--- a/copy.go
+++ b/copy.go
@@ -20,9 +20,9 @@ func (s *FsSyncer) copyContent(src, dst *os.File) (int64, error) {
 		nr, er := src.Read(buf)
 		if nr > 0 {
 			if s.noCache {
-				// Fadvise is a system call giving instruction to the OS about how to behave
-				// with the flag FADC_DONTNEED, it tell the OS to drop the disk cache
-				// on a given file, on a give part of the file (initial offset + end offset)
+				// Fadvise is a system call giving instruction to the OS about how to behave.
+				// With the flag FADC_DONTNEED, it tells the OS to drop the disk cache
+				// on a given file, on a given part of the file (initial offset + end offset)
 				// http://man7.org/linux/man-pages/man2/posix_fadvise.2.html
 				unix.Fadvise(int(src.Fd()), written, written+int64(nr), unix.FADV_DONTNEED)
 			}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/Scalingo/go-fssync
 
 go 1.13
 
-require github.com/pkg/errors v0.9.1
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/sync.go
+++ b/sync.go
@@ -79,7 +79,7 @@ func NoCache(s *FsSyncer) {
 	s.noCache = true
 }
 
-// WithBufferSize options lets you configure the size of the memory buffer used
+// WithBufferSize option: lets you configure the size of the memory buffer used
 // to perform the copy from one file to another
 // Default is 512kB
 func WithBufferSize(n int64) func(*FsSyncer) {

--- a/sync.go
+++ b/sync.go
@@ -25,15 +25,11 @@ type Syncer interface {
 }
 
 type FsSyncer struct {
-	// Check SHA1 checksum instead of modtime + size
-	checkChecksum bool
-	// Chown files from source owner instead of copying with current owner root
-	// required to change the user ownership in most cases
+	checkChecksum     bool
 	preserveOwnership bool
-	// If the synced directory is heavily used during the sync there might be a
-	// file which is walked in but which does not exist anymore when Lstat is
-	// used
-	ignoreNotFound bool
+	ignoreNotFound    bool
+	noCache           bool
+	bufferSize        int64
 }
 
 type fsSyncReport struct {
@@ -49,23 +45,47 @@ func (r fsSyncReport) ChangeCount() int {
 }
 
 func New(opts ...func(*FsSyncer)) *FsSyncer {
-	s := &FsSyncer{}
+	s := &FsSyncer{
+		bufferSize: 512 * 1024,
+	}
 	for _, opt := range opts {
 		opt(s)
 	}
 	return s
 }
 
+// WithChecksum option: Check SHA1 checksum instead of modtime + size
 func WithChecksum(s *FsSyncer) {
 	s.checkChecksum = true
 }
 
+// PreserveOwnership option: chown files from source owner instead of copying
+// with current owner root required to change the user ownership in most cases
 func PreserveOwnership(s *FsSyncer) {
 	s.preserveOwnership = true
 }
 
+// IgnoreNotFound option: if the synced directory is heavily used during the
+// sync there might be a file which is walked in but which does not exist
+// anymore when Lstat is used
 func IgnoreNotFound(s *FsSyncer) {
 	s.ignoreNotFound = true
+}
+
+// NoCache option: Use the system call fadvise to discard kernel cache after
+// reading/writing Inspired from
+// https://github.com/coreutils/coreutils/blob/master/src/dd.c
+func NoCache(s *FsSyncer) {
+	s.noCache = true
+}
+
+// WithBufferSize options lets you configure the size of the memory buffer used
+// to perform the copy from one file to another
+// Default is 512kB
+func WithBufferSize(n int64) func(*FsSyncer) {
+	return func(s *FsSyncer) {
+		s.bufferSize = n
+	}
 }
 
 type syncInfo struct {
@@ -360,7 +380,7 @@ func (s *FsSyncer) copyFileContent(src, dst string, info os.FileInfo) (int64, er
 		return -1, errors.Wrapf(err, "fail to open dest %v", dst)
 	}
 	defer fd.Close()
-	n, err := io.Copy(fd, sfd)
+	n, err := s.copyContent(sfd, fd)
 	if err != nil {
 		return -1, errors.Wrapf(err, "fail to copy data")
 	}


### PR DESCRIPTION
```
└> free -h                   
              total        used        free      shared  buff/cache   available
Mem:           15Gi       7.3Gi       3.1Gi       1.8Gi       5.1Gi       6.1Gi
Swap:          15Gi       4.0Gi        12Gi

└> fssync ./512m ./512m.copy

└> free -h
              total        used        free      shared  buff/cache   available
Mem:           15Gi       7.3Gi       2.6Gi       1.8Gi       5.7Gi       6.1Gi
Swap:          15Gi       4.0Gi        12Gi
```

Normal usage of cache: 3.1Gi -> 2.6Gi. Now with the new flag

```
└> free -h
              total        used        free      shared  buff/cache   available
Mem:           15Gi       7.3Gi       2.6Gi       1.8Gi       5.7Gi       6.1Gi
Swap:          15Gi       4.0Gi        12Gi

└> fssync -no-cache ./512m ./512m.copy.2

└> free -h
              total        used        free      shared  buff/cache   available
Mem:           15Gi       7.3Gi       2.6Gi       1.8Gi       5.7Gi       6.1Gi
Swap:          15Gi       4.0Gi        12Gi
```