### PR TITLE
test(sync): restore failing tests

### DIFF
--- a/sync_test.go
+++ b/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,23 @@ func TestFsSyncer_Sync(t *testing.T) {
 		"it should copy a directory": {
 			fixtureSrc: "src/dir",
 		},
+		"it should copy a hard link": {
+			fixtureSrc: "src/hardlink",
+			additionalSpecs: func(t *testing.T, src, dst string) {
+				apath := filepath.Join(dst, "a")
+				bpath := filepath.Join(dst, "b")
+
+				astat, err := os.Lstat(apath)
+				assert.NoError(t, err)
+
+				bstat, err := os.Lstat(bpath)
+				assert.NoError(t, err)
+
+				asysstat := astat.Sys().(*syscall.Stat_t)
+				bsysstat := bstat.Sys().(*syscall.Stat_t)
+				assert.Equal(t, asysstat.Ino, bsysstat.Ino)
+			},
+		},
 		"it should copy a symlink": {
 			fixtureSrc: "src/symlink",
 		},
@@ -42,6 +60,16 @@ func TestFsSyncer_Sync(t *testing.T) {
 		},
 		"it should keep the symlink to a relative path": {
 			fixtureSrc: "src/relative-symlink",
+		},
+		"it should replace a file with the same content but not the same mtime": {
+			fixtureSrc:      "src/file",
+			fixtureDst:      "dst/cp-file",
+			expectedChanges: []string{"a"},
+		},
+		"it should replace a file with the same size but not the same mtime": {
+			fixtureSrc:      "src/file",
+			fixtureDst:      "dst/same-size",
+			expectedChanges: []string{"a"},
 		},
 		"it should not replace a file with the same content but not the same mtime if checksum checks are enabled": {
 			fixtureSrc:      "src/file",


### PR DESCRIPTION
In the commit b0bb006de1172f72a53e99b2cd47a36bf2f184f9, I removed the failing tests as I want to have a CI that passes on `master`. This PR is opened to work on restoring these failing tests.